### PR TITLE
Update Kafka broker variable docs

### DIFF
--- a/post-service/.env.example
+++ b/post-service/.env.example
@@ -10,7 +10,8 @@ DATABASE_URL="postgresql://username:password@localhost:5432/post_db"
 USER_SERVICE_URL=http://localhost:3001
 
 # Kafka Configuration
-KAFKA_BROKER=localhost:9092
+# Comma-separated list of Kafka brokers
+KAFKA_BROKERS=localhost:9092
 
 # Node Environment
 NODE_ENV=development

--- a/post-service/README.md
+++ b/post-service/README.md
@@ -122,8 +122,10 @@ See [API_SPEC.md](API_SPEC.md) for detailed API documentation.
 | `PORT` | Server port | `3002` |
 | `DATABASE_URL` | PostgreSQL connection string | - |
 | `USER_SERVICE_URL` | User service base URL | `http://localhost:3001` |
-| `KAFKA_BROKER` | Kafka broker address | `localhost:9092` |
+| `KAFKA_BROKERS` | Kafka broker addresses (comma-separated) | `localhost:9092` |
 | `NODE_ENV` | Environment mode | `development` |
+
+`KAFKA_BROKERS` can contain a comma-separated list of broker addresses.
 
 ## Database Schema
 
@@ -189,7 +191,7 @@ The service consumes the following Kafka events:
 
 2. **Kafka Connection Issues:**
    - Verify Kafka broker is running
-   - Check KAFKA_BROKER environment variable
+   - Check KAFKA_BROKERS environment variable
    - Ensure topic 'user.updated' exists
 
 3. **User Service Communication:**


### PR DESCRIPTION
## Summary
- rename `KAFKA_BROKER` to `KAFKA_BROKERS` in docs and examples
- clarify that the variable accepts a comma-separated broker list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684e5c94dd8083218092bbe851dda859