### PR TITLE
Add existing follow check in user controller

### DIFF
--- a/user-service/src/routes/user.controller.ts
+++ b/user-service/src/routes/user.controller.ts
@@ -165,8 +165,13 @@ export const followUser = async (req: Request, res: Response) => {
     await userService.followUser(userId, targetUserId);
 
     res.status(200).json({ message: 'Successfully followed user' });
-  } catch (error) {
+  } catch (error: any) {
     console.error('Follow user error:', error);
+
+    if (error instanceof Error && error.message === 'Already following this user') {
+      return res.status(400).json({ error: 'Already following this user' });
+    }
+
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/user-service/tests/user.controller.test.ts
+++ b/user-service/tests/user.controller.test.ts
@@ -293,6 +293,46 @@ describe('User Controller Integration Tests', () => {
       expect(response.body).toHaveProperty('error', 'You cannot follow yourself');
     });
 
+    it('should return 400 when already following the user', async () => {
+      const mockFollower = {
+        id: 'user-1',
+        username: 'user1',
+        email: 'user1@example.com',
+        password_hash: 'hash',
+        created_at: new Date(),
+      };
+
+      const mockFollowed = {
+        id: 'user-2',
+        username: 'user2',
+        email: 'user2@example.com',
+        password_hash: 'hash',
+        created_at: new Date(),
+      };
+
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce(mockFollower)
+        .mockResolvedValueOnce(mockFollowed);
+      mockPrisma.follow.findFirst.mockResolvedValue({
+        id: 'existing-follow',
+        follower_id: 'user-1',
+        followed_id: 'user-2',
+        followed_at: new Date(),
+      });
+
+      const token = jwt.sign({ id: 'user-1', username: 'user1' }, 'test-secret');
+
+      const response = await request(app)
+        .post('/users/user-1/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          targetUserId: 'user-2',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error', 'Already following this user');
+    });
+
     it('should return 403 when trying to follow for another user', async () => {
       const token = jwt.sign({ id: 'user-1', username: 'user1' }, 'test-secret');
 


### PR DESCRIPTION
## Summary
- test scenario when follow relationship already exists
- handle 'already following' error in controller

## Testing
- `npm test --silent --prefix user-service` *(fails: jest not found)*
- `npx --prefix user-service jest` *(fails: npm ERR 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684e5c9692dc8321970a3eb625525b73